### PR TITLE
94 jg addback length encoding - Added back the length encoding to deal with variable length private keys

### DIFF
--- a/draft-ietf-lamps-pq-composite-sigs.md
+++ b/draft-ietf-lamps-pq-composite-sigs.md
@@ -169,10 +169,13 @@ This document defines combinations of ML-DSA [FIPS.204] in hybrid with tradition
 Interop-affecting changes:
 
 * Remove the ASN.1 SEQUENCE Wrapping around the Public Keys, Private Keys and Composite Signature Value
-* TODO Remove the HashComposite-ML-DSA algorithms in favour of the external Mu hashing
+* Added a prefix into the message format to allow traditional verifiers to detect if a composite signature has been stripped
+* Added a fixed 4-byte length value to identify the length of the first ML-DSA component so keys and signatures can be separated
+* Issued new prototype OIDs for testing purposes since the above changes break backwards compatiblity with version -03
 
 Editorial changes:
-
+* Added normative language to make it clear that key reuse is prohibited
+* Updated the security considerations section
 
 # Introduction {#sec-intro}
 

--- a/draft-ietf-lamps-pq-composite-sigs.md
+++ b/draft-ietf-lamps-pq-composite-sigs.md
@@ -713,7 +713,7 @@ Serialization Process:
      mldsaEncodedKey = MLDSA.SerializeKey(mldsaKey)
      tradEncodedKey = Trad.SerializeKey(tradKey)
 
-  3. Calculate the length encoding of the mldsaEncodedPK 
+  3. Calculate the length encoding of the mldsaEncodedPK
 
      encodedLength = IntegerToBytes(mldsaEncodeKey.length, 4)
 
@@ -754,8 +754,8 @@ Deserialization Process:
       output "Deserialization error"
 
   2. Parse each constituent encoded key.
-       The first 4 bytes encodes the length of mldsaEncodedKey, which MAY 
-       be used to separate the mldsaEncodedKey and tradEncodedKey, and then 
+       The first 4 bytes encodes the length of mldsaEncodedKey, which MAY
+       be used to separate the mldsaEncodedKey and tradEncodedKey, and then
        is to be discarded.
 
      (mldsaEncodedKey, tradEncodedKey) = bytes
@@ -780,7 +780,7 @@ Deserialization Process:
 
 ## SerializeSignatureValue and DeSerializeSignatureValue
 
-The serialization routine for the CompositeSignatureValue simply concatenates the 
+The serialization routine for the CompositeSignatureValue simply concatenates the
 ML-DSA signature value with the signature value from the traditional algorithm, as defined below:
 
 ~~~
@@ -817,7 +817,7 @@ Serialization Process:
      mldsaEncodedSignature = ML-DSA.SerializeSignature(mldsaSig)
      tradEncodedSignature = Trad.SerializeSignature(tradSig)
 
-  3. Calculate the length encoding of the mldsaEncodedSignature 
+  3. Calculate the length encoding of the mldsaEncodedSignature
 
      encodedLength = IntegerToBytes(mldsaEncodedSignature.length, 4)
 
@@ -858,7 +858,7 @@ Deserialization Process:
       output "Deserialization error"
 
   2. Parse each constituent encoded signature.
-       The first 4 bytes encodes the length of mldsaEncodedSignature, which MAY 
+       The first 4 bytes encodes the length of mldsaEncodedSignature, which MAY
        be used to separate the mldsaEncodedSignature and tradEncodedSignature,
        and then is to be discarded.
 
@@ -886,7 +886,7 @@ Deserialization Process:
 
 As noted above, the composite public key, composite private key and composite signature value
 serialization and deserialization methods use a fixed 4-byte length value to indicate the size of
-the first component.  This is to allow the separation of the first component from the second 
+the first component.  This is to allow the separation of the first component from the second
 component.  It is RECOMMENDED that the length specified for the first component be checked against
 the values from the table below to ensure the encoding has been done propertly.
 
@@ -899,7 +899,7 @@ sizes for ML-DSA which can be used to deserialzie the components.
 
 | Algorithm | Public key  | Private key  | Signature |
 | ----------- | ----------- | ----------- |  ----------- |
-| ML-DSA-44 |      1312     |    32 or 2560 or 2592    |  2420        |
+| ML-DSA-44 |      1312     |    32 or 2560 or 2592    |  2420  |
 | ML-DSA-65 |      1952     |    32 or 4032 or 4064    |  3309  |
 | ML-DSA-87 |      2592     |    32 or 4896 or 4928    |  4627   |
 {: #tab-mldsa-sizes title="ML-DSA Key and Signature Sizes in bytes"}


### PR DESCRIPTION
Added back the length encode for keys and signatures.  The main purpose is to deal with the variable length private key issue.  Added for public keys and signatures as well for consistency. 