### PR TITLE
SMIME-CAPS missing from ASN.1 Definitions section (it's there in ASN.…

### DIFF
--- a/draft-ietf-lamps-pq-composite-sigs.md
+++ b/draft-ietf-lamps-pq-composite-sigs.md
@@ -986,6 +986,7 @@ sa-CompositeSignature{OBJECT IDENTIFIER:id,
          -- VALUE no ASN.1 wrapping --
          PARAMS ARE absent
          PUBLIC-KEYS {publicKeyType}
+         SMIME-CAPS { IDENTIFIED BY id }
       }
 ~~~
 {: #asn1-info-classes title="ASN.1 Object Information Classes for Composite ML-DSA"}


### PR DESCRIPTION
…1 Module section)