### PR TITLE
fix: Appendix D MLDSA65-ECDSA-P256-SHA256 -> SHA512 in M' examples

### DIFF
--- a/draft-ietf-lamps-pq-composite-sigs.md
+++ b/draft-ietf-lamps-pq-composite-sigs.md
@@ -1944,13 +1944,13 @@ Each input component is shown. Note that values are shown hex-encoded for displa
 
 Finally, the fully assembled `M'` is given, which is simply the concatenation of the above values.
 
-First is an example of constructing the message representative `M'` for MLDSA65-ECDSA-P256-SHA256 without a context string `ctx`.
+First is an example of constructing the message representative `M'` for MLDSA65-ECDSA-P256-SHA512 without a context string `ctx`.
 
 ~~~
 {::include ./src/messageFormatSample_noctx.md}
 ~~~
 
-Second is an example of constructing the message representative `M'` for MLDSA65-ECDSA-P256-SHA256 with a context string `ctx`.
+Second is an example of constructing the message representative `M'` for MLDSA65-ECDSA-P256-SHA512 with a context string `ctx`.
 
 The inputs are similar to the first example with the exception that there is an 8-byte context string 'ctx'.
 


### PR DESCRIPTION
## 概要

#360 で報告されている Appendix D の typo を修正します。

`draft-ietf-lamps-pq-composite-sigs.md` 内の Appendix D「Message Representative Examples」セクションで、M' を構築する 2 つの prose 文が `MLDSA65-ECDSA-P256-SHA256` と記述されていましたが、対象アルゴリズムは `MLDSA65-ECDSA-P256-SHA512` です(同文書 L1380 周辺の `id-MLDSA65-ECDSA-P256-SHA512` 定義と整合)。

reporter は John Gray が typo であることを確認済みと記載しています。

対象:

- L1947: `First is an example ... for MLDSA65-ECDSA-P256-SHA256 without a context string` → `SHA512`
- L1953: `Second is an example ... for MLDSA65-ECDSA-P256-SHA256 with a context string` → `SHA512`

Closes #360

## 動作確認

- 変更は **`draft-ietf-lamps-pq-composite-sigs.md` の 2 行のみ**(SHA256 → SHA512)
- 他の `SHA256` 参照(`ecdsa-with-SHA256` / `ecdsa-with-SHA256 with secp256r1` 等 ECDSA 内部ハッシュ仕様、L1337/1338/1522 ほか)は全て保持
- `grep -c "MLDSA65-ECDSA-P256-SHA256"` 結果が `2` → `0`、`MLDSA65-ECDSA-P256-SHA512` は `4` → `6`(両 prose 行に正しいアルゴリズム名)
- gitleaks v8.30.1 でスキャン clean
- ASN.1 / Makefile / src/ は無変更